### PR TITLE
soc: qcom: watchdog_v2: Fix memory leaks when memory_dump_v2 isn't built

### DIFF
--- a/drivers/soc/qcom/watchdog_v2.c
+++ b/drivers/soc/qcom/watchdog_v2.c
@@ -666,6 +666,9 @@ static void configure_bark_dump(struct msm_watchdog_data *wdog_dd)
 	int cpu;
 	void *cpu_buf;
 
+	if (!IS_ENABLED(CONFIG_QCOM_MEMORY_DUMP_V2))
+		return;
+
 	cpu_data = kcalloc(num_present_cpus(), sizeof(struct msm_dump_data),
 								GFP_KERNEL);
 	if (!cpu_data)


### PR DESCRIPTION
When the memory-dump driver isn't built (CONFIG_QCOM_MEMORY_DUMP_V2=n),
an inline version of msm_dump_data_register() will be used that does
nothing. This means that all memory allocated with the intention of
going to msm_dump_data_register() will be leaked.

Fix this by skipping configure_bark_dump() when
CONFIG_QCOM_MEMORY_DUMP_V2 is disabled.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>